### PR TITLE
chore: sync main into develop

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -1,4 +1,4 @@
-name: Pull Request to Develop
+name: Pull Request to Main
 
 on:
   pull_request:

--- a/.github/workflows/push-promote-staging.yml
+++ b/.github/workflows/push-promote-staging.yml
@@ -1,7 +1,7 @@
 name: Promote to Staging
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       cr_number:
         description: "CR Number"

--- a/.github/workflows/push-promote-staging.yml
+++ b/.github/workflows/push-promote-staging.yml
@@ -1,0 +1,21 @@
+name: Promote to Staging
+
+on:
+  workflow_call:
+    inputs:
+      cr_number:
+        description: "CR Number"
+        required: true
+        type: string
+      release_branch_name:
+        description: "Docker image tag to promote (e.g. release/release-name)"
+        required: true
+        type: string
+
+jobs:
+  central:
+    uses: canpolato/core-pipelines/.github/workflows/core-promote-staging.yml@main
+    secrets: inherit
+    with:
+      cr_number: ${{ inputs.cr_number }}
+      release_branch_name: ${{ inputs.release_branch_name }}

--- a/.github/workflows/push-promote-staging.yml
+++ b/.github/workflows/push-promote-staging.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       release_branch_name:
-        description: "Docker image tag to promote (e.g. release/release-name)"
+        description: "Release branch to promote (e.g. release/release-name)"
         required: true
         type: string
 

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -6,5 +6,6 @@ on:
 
 jobs:
   central:
+    if: github.event.created == false
     uses: canpolato/core-pipelines/.github/workflows/core-push-release.yml@main
     secrets: inherit

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   central:
-    if: github.event.created == false
+    # if: github.event.created == false
     uses: canpolato/core-pipelines/.github/workflows/core-push-release.yml@main
     secrets: inherit

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const port = process.env.PORT || 3000;
 
 const server = http.createServer((req, res) => {
   res.statusCode = 200;
-  const msg = 'Hello Node 101 !\n'
+  const msg = 'Hello Node 103 !\n'
   res.end(msg);
 });
 


### PR DESCRIPTION
## Summary
- Brings `develop` back in line with `main` (was 20 commits behind, 2 ahead).
- Most of the 20 main-only commits are prior release merges that were never merged back into `develop` — standard git-flow housekeeping.
- Clean merge, no conflicts. Three files auto-merged in `.github/workflows/` (`pr-main.yml`, `push-promote-staging.yml`, `push-release.yml`).

## Test plan
- [ ] Confirm CI passes on the sync branch.
- [ ] Once merged, verify `origin/develop` and `origin/main` have a 0-commit divergence (`git rev-list --left-right --count origin/main...origin/develop` → `0 0`).
- [ ] Cut the next `release/<N>` from `main` + merge `develop` in to confirm there's no leftover conflict.