### PR TITLE
hotfix: surface release branch and CR in staging-promote run-name (CR-0)

### DIFF
--- a/.github/workflows/push-promote-staging.yml
+++ b/.github/workflows/push-promote-staging.yml
@@ -1,4 +1,5 @@
 name: Promote to Staging
+run-name: "Promote ${{ inputs.release_branch_name }} to STG · CR-${{ inputs.cr_number }} · by @${{ github.actor }}"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Adds `run-name:` to `push-promote-staging.yml` so the workflow-run title shows the release branch, CR number, and operator — visible to approvers in the run list, run header, and GitHub email notifications.
- Pairs with `core-pipelines` commit `6e5649b` (step summary + dispatch-source check).
- No functional code change — workflow run titling only.

CR-0 (housekeeping change; no real CR to attach).

## Test plan
- [ ] After merge, dispatch the workflow from `main` and confirm the run title reads `Promote release/<N> to STG · CR-<num> · by @<actor>`.
- [ ] Confirm the workflow still works end-to-end (resolves SHA via git ls-remote, runs the two approvals, writes `release-<sha>` to `values-stg.yaml`).