### PR TITLE
chore(stg-promote): set run-name with release branch and CR

### DIFF
--- a/.github/workflows/push-promote-staging.yml
+++ b/.github/workflows/push-promote-staging.yml
@@ -1,4 +1,5 @@
 name: Promote to Staging
+run-name: "Promote ${{ inputs.release_branch_name }} to STG · CR-${{ inputs.cr_number }} · by @${{ github.actor }}"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
So approvers and anyone browsing Actions can tell at a glance which release branch and CR a staging promotion is for, instead of just "Promote to Staging #N".